### PR TITLE
添加 vs-plugins 目录结构

### DIFF
--- a/vs-plugins/.gitattributes
+++ b/vs-plugins/.gitattributes
@@ -1,0 +1,7 @@
+# 为大型二进制文件配置 Git LFS
+*.dll filter=lfs diff=lfs merge=lfs -text
+*.ax filter=lfs diff=lfs merge=lfs -text
+*.onnx filter=lfs diff=lfs merge=lfs -text
+*.engine filter=lfs diff=lfs merge=lfs -text
+*.engine.cache filter=lfs diff=lfs merge=lfs -text
+*.bin filter=lfs diff=lfs merge=lfs -text

--- a/vs-plugins/README.md
+++ b/vs-plugins/README.md
@@ -1,0 +1,17 @@
+# vs-plugins 目录
+
+此目录包含 MPV-lazy-full 的 VapourSynth 插件文件。
+
+## 目录结构
+
+- `madVR/` - madVR 相关文件
+- `models/` - 各种模型文件，包括 ONNX 模型
+- 各种 .dll 文件 - VapourSynth 插件
+
+## 注意事项
+
+由于 GitHub 对文件大小和数量有限制，建议通过 Git LFS（Large File Storage）上传大型二进制文件。
+
+## 完整内容
+
+要获取完整的 vs-plugins 内容，请参考项目说明或从发布页面下载。

--- a/vs-plugins/madVR/README.md
+++ b/vs-plugins/madVR/README.md
@@ -1,0 +1,9 @@
+# madVR 目录
+
+此目录包含 madVR 相关文件，包括：
+
+- madHcNet64.dll
+- madVR64.ax
+- mvrSettings64.dll
+
+由于这些文件较大，建议通过 Git LFS 上传或从发布页面下载完整内容。

--- a/vs-plugins/models/README.md
+++ b/vs-plugins/models/README.md
@@ -1,0 +1,20 @@
+# models 目录
+
+此目录包含各种模型文件，主要是 ONNX 格式的模型文件，用于视频处理和增强。
+
+## 子目录
+
+- `ArtCNN/` - ArtCNN 相关模型
+- `RealESRGANv2/` - RealESRGAN v2 相关模型
+- `rife/` - RIFE 相关模型
+- `rife-v4.25-lite_ensembleFalse/` - RIFE v4.25 轻量版模型
+- `rife-v4.26-large_ensembleFalse/` - RIFE v4.26 大型模型
+- `rife-v4.26_ensembleFalse/` - RIFE v4.26 标准模型
+- `rife-v4.6_ensembleFalse/` - RIFE v4.6 标准模型
+- `rife-v4.6_ensembleTrue/` - RIFE v4.6 集成模型
+- `rife_v2/` - RIFE v2 相关模型
+- `waifu2x/` - Waifu2x 相关模型
+
+## 注意事项
+
+由于模型文件通常较大，建议通过 Git LFS 上传或从发布页面下载完整内容。


### PR DESCRIPTION
此 PR 添加了 vs-plugins 目录的基本结构，包括：

1. 创建 vs-plugins 目录及其说明文件
2. 创建 madVR 子目录及其说明文件
3. 创建 models 子目录及其说明文件
4. 添加 Git LFS 配置文件，用于管理大型二进制文件

由于 GitHub 对文件大小和数量有限制，此 PR 只包含目录结构和说明文件，不包含实际的二进制文件。要上传完整的 vs-plugins 内容，建议：

1. 克隆此仓库到本地
2. 安装 Git LFS
3. 将本地的 vs-plugins 目录中的文件复制到仓库中
4. 使用 Git LFS 追踪大型二进制文件
5. 提交并推送更改

或者，可以考虑将大型二进制文件放在发布页面或其他存储服务中，并在 README 中提供下载链接。